### PR TITLE
Increases CI coverage

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,6 +22,13 @@ jobs:
             coverage: OFF
             cc: gcc-10
             cxx: g++-10
+          - os: ubuntu
+            os_ver: "18.04"
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            cc: gcc-9
+            cxx: g++-9
           - os: windows
             os_ver: "2022"
             config: Release
@@ -65,19 +72,19 @@ jobs:
       - name: Create Build Directory
         run: cmake -E make_directory ${{github.workspace}}/build
       - name: Install Linux Libraries
-        if: runner.os == 'ubuntu'
+        if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get -y install xorg-dev libgl1-mesa-dev
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -D${{ env.REPOSITORY_NAME }}_BUILD_TESTING="ON" -D${{ env.REPOSITORY_NAME }}_STATIC_LIB="${{ matrix.static_lib }}" -D${{ env.REPOSITORY_NAME }}_COVERAGE="${{ matrix.coverage }}"
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Download Mesa3D on Windows
-        if: runner.os == 'windows'
+        if: runner.os == 'Windows'
         shell: cmd
         run: curl.exe -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/20.3.2/mesa3d-20.3.2-release-msvc.7z
         working-directory: build\test\${{ matrix.config }}
       - name: Install Mesa3D on Windows
-        if: runner.os == 'windows'
+        if: runner.os == 'Windows'
         shell: cmd
         run: |
           "C:\Program Files\7-Zip\7z.exe" x mesa.7z

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,17 +8,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: [ubuntu-20.04, ubuntu-22.04]
+          - os: ubuntu-22.04
             config: Release
             static_lib: ON
             coverage: OFF
-            include:
-              - os: ubuntu-20.04
-                cc: gcc-10
-                cxx: g++-10
-              - os: ubuntu-22.04
-                cc: gcc-11
-                cxx: g++-11
+            cc: gcc-11
+            cxx: g++-11
+          - os: ubuntu-20.04
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            cc: gcc-10
+            cxx: g++-10
           - os: windows-2022
             config: Release
             static_lib: ON

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,30 +8,49 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             config: Release
             static_lib: ON
             coverage: OFF
-          - os: windows-latest
+            cc: gcc-11
+            cxx: gcc-11
+          - os: ubuntu-20.04
             config: Release
             static_lib: ON
             coverage: OFF
-          - os: macos-latest
+            cc: gcc-10
+            cxx: gcc-10
+          - os: windows-2022
             config: Release
             static_lib: ON
             coverage: OFF
-          - os: ubuntu-18.04
+            cc: cl
+            cxx: cl
+          - os: macos-12
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            cc: clang
+            cxx: clang++
+          - os: macos-11
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            cc: clang
+            cxx: clang++
+          - os: ubuntu-20.04
             config: Debug
             static_lib: OFF
             coverage: ON
-          - os: ubuntu-latest
-            config: Release
-            static_lib: ON
-            coverage: OFF
+            cc: gcc-10
+            cxx: gcc-10
       fail-fast: false
     defaults:
       run:
         shell: bash
+    env:
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,25 +8,29 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu
+            os_ver: "22.04"
             config: Release
             static_lib: ON
             coverage: OFF
             cc: gcc-11
             cxx: g++-11
-          - os: ubuntu-20.04
+          - os: ubuntu
+            os_ver: "20.04"
             config: Release
             static_lib: ON
             coverage: OFF
             cc: gcc-10
             cxx: g++-10
-          - os: windows-2022
+          - os: windows
+            os_ver: "2022"
             config: Release
             static_lib: ON
             coverage: OFF
             cc: cl
             cxx: cl
-          - os: macos-12
+          - os: macos
+            os_ver: "12"
             config: Release
             static_lib: ON
             coverage: OFF
@@ -38,7 +42,8 @@ jobs:
             coverage: OFF
             cc: clang
             cxx: clang++
-          - os: ubuntu-20.04
+          - os: ubuntu
+            os_ver: "20.04"
             config: Debug
             static_lib: OFF
             coverage: ON
@@ -51,7 +56,7 @@ jobs:
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-${{ matrix.os_ver }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -60,19 +65,19 @@ jobs:
       - name: Create Build Directory
         run: cmake -E make_directory ${{github.workspace}}/build
       - name: Install Linux Libraries
-        if: runner.os == 'Linux'
+        if: runner.os == 'ubuntu'
         run: sudo apt-get update && sudo apt-get -y install xorg-dev libgl1-mesa-dev
       - name: Configure CMake
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -D${{ env.REPOSITORY_NAME }}_BUILD_TESTING="ON" -D${{ env.REPOSITORY_NAME }}_STATIC_LIB="${{ matrix.static_lib }}" -D${{ env.REPOSITORY_NAME }}_COVERAGE="${{ matrix.coverage }}"
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Download Mesa3D on Windows
-        if: runner.os == 'Windows'
+        if: runner.os == 'windows'
         shell: cmd
         run: curl.exe -L --output mesa.7z --url https://github.com/pal1000/mesa-dist-win/releases/download/20.3.2/mesa3d-20.3.2-release-msvc.7z
         working-directory: build\test\${{ matrix.config }}
       - name: Install Mesa3D on Windows
-        if: runner.os == 'Windows'
+        if: runner.os == 'windows'
         shell: cmd
         run: |
           "C:\Program Files\7-Zip\7z.exe" x mesa.7z

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,13 +22,6 @@ jobs:
             coverage: OFF
             cc: gcc-10
             cxx: g++-10
-          - os: ubuntu
-            os_ver: "18.04"
-            config: Release
-            static_lib: ON
-            coverage: OFF
-            cc: gcc-9
-            cxx: g++-9
           - os: windows
             os_ver: "2022"
             config: Release

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,8 @@ jobs:
             coverage: OFF
             cc: clang
             cxx: clang++
-          - os: macos-11
+          - os: macos
+            os_ver: "11"
             config: Release
             static_lib: ON
             coverage: OFF

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,13 +22,13 @@ jobs:
             coverage: OFF
             cc: gcc-10
             cxx: g++-10
-          - os: ubuntu
-            os_ver: "18.04"
-            config: Release
-            static_lib: ON
-            coverage: OFF
-            cc: gcc-9
-            cxx: g++-9
+          # - os: ubuntu
+          #   os_ver: "18.04"
+          #   config: Release
+          #   static_lib: ON
+          #   coverage: OFF
+          #   cc: gcc-9
+          #   cxx: g++-9
           - os: windows
             os_ver: "2022"
             config: Release

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,13 +13,13 @@ jobs:
             static_lib: ON
             coverage: OFF
             cc: gcc-11
-            cxx: gcc-11
+            cxx: g++-11
           - os: ubuntu-20.04
             config: Release
             static_lib: ON
             coverage: OFF
             cc: gcc-10
-            cxx: gcc-10
+            cxx: g++10
           - os: windows-2022
             config: Release
             static_lib: ON
@@ -43,7 +43,7 @@ jobs:
             static_lib: OFF
             coverage: ON
             cc: gcc-10
-            cxx: gcc-10
+            cxx: g++-10
       fail-fast: false
     defaults:
       run:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,13 +22,13 @@ jobs:
             coverage: OFF
             cc: gcc-10
             cxx: g++-10
-          # - os: ubuntu
-          #   os_ver: "18.04"
-          #   config: Release
-          #   static_lib: ON
-          #   coverage: OFF
-          #   cc: gcc-9
-          #   cxx: g++-9
+          - os: ubuntu
+            os_ver: "18.04"
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            cc: gcc-9
+            cxx: g++-9
           - os: windows
             os_ver: "2022"
             config: Release

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,18 +8,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: [ubuntu-20.04, ubuntu-22.04]
             config: Release
             static_lib: ON
             coverage: OFF
-            cc: gcc-11
-            cxx: g++-11
-          - os: ubuntu-20.04
-            config: Release
-            static_lib: ON
-            coverage: OFF
-            cc: gcc-10
-            cxx: g++-10
+            include:
+              - os: ubuntu-20.04
+                cc: gcc-10
+                cxx: g++-10
+              - os: ubuntu-22.04
+                cc: gcc-11
+                cxx: g++-11
           - os: windows-2022
             config: Release
             static_lib: ON

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
             static_lib: ON
             coverage: OFF
             cc: gcc-10
-            cxx: g++10
+            cxx: g++-10
           - os: windows-2022
             config: Release
             static_lib: ON

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Penumbra is a free and open source library for GPU accelerated solar shading cal
 
 ## Building penumbra from source
 
-1. Clone the git repository, or download and extract the source code ([tar.gz](https://github.com/bigladder/penumbra/archive/refs/tags/v0.3.3.tar.gz) or [zip](https://github.com/bigladder/penumbra/archive/refs/tags/v0.3.3.zip)).
+1. Clone the git repository.
 2. Make a directory called `build` inside the top level of your source.
 3. Open a console in the `build` directory.
 4. Type `cmake ..`.

--- a/README.md
+++ b/README.md
@@ -3,4 +3,17 @@
 
 # Penumbra
 
-Penumbra is a free and open source library for GPU accelerated solar shading calculations using [pixel counting](http://www.ibpsa.org/proceedings/BS2011/P_1271.pdf).
+Penumbra is a free and open source library for GPU accelerated solar shading calculations using [pixel counting](http://www.ibpsa.org/proceedings/BS2011/P_1271.pdf). It is configured as a cross-platform CMake project. 
+
+## Pre-requisites:
+
+1. A C++ compiler (e.g., Clang, GCC, MSVC)
+2. CMake
+
+## Building penumbra from source
+
+1. Clone the git repository, or download and extract the source code (`tar.gz` or `zip`).
+2. Make a directory called `build` inside the top level of your source.
+3. Open a console in the `build` directory.
+4. Type `cmake ..`.
+5. Type `cmake --build . --config Release`.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Penumbra is a free and open source library for GPU accelerated solar shading cal
 
 ## Building penumbra from source
 
-1. Clone the git repository, or download and extract the source code (`tar.gz` or `zip`).
+1. Clone the git repository, or download and extract the source code ([tar.gz](https://github.com/bigladder/penumbra/archive/refs/tags/v0.3.3.tar.gz) or [zip](https://github.com/bigladder/penumbra/archive/refs/tags/v0.3.3.zip)).
 2. Make a directory called `build` inside the top level of your source.
 3. Open a console in the `build` directory.
 4. Type `cmake ..`.


### PR DESCRIPTION
## Description

Major changes:
- Adds more specificity to the os version and the compiler version
- Add `gcc-9` for Ubuntu-18.04 (deprecated)
- Adds Ubuntu-22.04 and macOS-12 to the CI matrix
- Adds `gcc-10` and `gcc-11` coverage

Minor changes:
- Updates README.
