### PR TITLE
Add MT and MTd flag for their respective configuration

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}-${{ matrix.os_ver }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
       - name: Set Project Name
         run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
       - name: Create Build Directory
@@ -86,7 +86,7 @@ jobs:
           mklink libglapi.dll "x64\libglapi.dll"
         working-directory: build\test\${{ matrix.config }}
       - name: Test
-        uses: GabrielBB/xvfb-action@v1.6
+        uses: GabrielBB/xvfb-action@v1
         with:
           run: ctest -C ${{ matrix.config }} --output-on-failure
           working-directory: build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}-${{ matrix.os_ver }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5
       - name: Set Project Name
         run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
       - name: Create Build Directory

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}-${{ matrix.os_ver }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.5
+        uses: actions/checkout@v3
       - name: Set Project Name
         run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
       - name: Create Build Directory

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -86,7 +86,7 @@ jobs:
           mklink libglapi.dll "x64\libglapi.dll"
         working-directory: build\test\${{ matrix.config }}
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
+        uses: GabrielBB/xvfb-action@v1.6
         with:
           run: ctest -C ${{ matrix.config }} --output-on-failure
           working-directory: build

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -17,7 +17,7 @@ target_compile_options(penumbra_common_interface INTERFACE
   $<$<CXX_COMPILER_ID:MSVC>: # Visual C++ (VS 2013)
     /nologo
     /EHsc
-    /W3
+    /W4
     /WX
     $<$<CONFIG:Release>:
       /GS-    # Disable buffer overrun checks for performance in release mode

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -17,17 +17,18 @@ target_compile_options(penumbra_common_interface INTERFACE
   $<$<CXX_COMPILER_ID:MSVC>: # Visual C++ (VS 2013)
     /nologo
     /EHsc
-    /MT
     /W3
     /WX
     $<$<CONFIG:Release>:
       /GS-    # Disable buffer overrun checks for performance in release mode
+      /MT     # Causes the application to use the multithread, static version of the run-time library, using LIBCMT.lib.
     >
     $<$<CONFIG:Debug>:
       /Zi     #
       /Ob0    # Disable inlining
       /Od     # Turns off all optimizations in the program and speeds compilation
       /RTC1   # Runtime checks
+      /MTd    # Debug multithreaded executable file using LIBCMTD.lib.
     >
   >
   # GCC

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -8,134 +8,186 @@ set(CMAKE_EXE_LINKER_FLAGS_RELEASE "")
 set(CMAKE_EXE_LINKER_FLAGS_DEBUG "")
 
 add_library(penumbra_common_interface INTERFACE)
+set(use_msvc "$<CXX_COMPILER_ID:MSVC>")
+set(use_gcc "$<CXX_COMPILER_ID:GNU>")
+set(use_clang "$<CXX_COMPILER_ID:CLANG>")
+set(use_win32_intel "$<AND:$<BOOL:${WIN32}>,$<CXX_COMPILER_ID:Intel>>")
+set(use_unix_intel "$<AND:$<BOOL:${UNIX}>,$<CXX_COMPILER_ID:Intel>>")
+set(release_config "$<CONFIG:Release>")
+set(debug_config "$<CONFIG:Debug>")
+set(use_msvc_release "$<AND:${use_msvc},${release_config}>")
+set(use_msvc_debug "$<AND:${use_msvc},${debug_config}>")
+set(use_gcc_release "$<AND:${use_gcc},${release_config}>")
+set(use_gcc_debug "$<AND:${use_gcc},${debug_config}>")
+set(use_clang_release "$<AND:${use_clang},${release_config}>")
+set(use_clang_debug "$<AND:${use_clang},${debug_config}>")
+set(use_win32_intel_release "$<AND:${use_win32_intel},${release_config}>")
+set(use_win32_intel_debug "$<AND:${use_win32_intel},${debug_config}>")
+set(use_unix_intel_release "$<AND:${use_unix_intel},${release_config}>")
+set(use_unix_intel_debug "$<AND:${use_unix_intel},${debug_config}>")
+
+  #================#
+  #   MSVC flags   #
+  #================#
+
+set(msvc_common
+  /nologo
+  /EHsc
+  /W4
+  /WX
+)
+
+set(msvc_release
+  "${msvc_common}"
+  /GS-    # Disable buffer overrun checks for performance in release mode
+  /MT     # Causes the application to use the multithread, static version of the run-time library, using LIBCMT.lib.
+)
+
+set(msvc_debug
+  "${msvc_common}"
+  /Zi     #
+  /Ob0    # Disable inlining
+  /Od     # Turns off all optimizations in the program and speeds compilation
+  /RTC1   # Runtime checks
+  /MTd    # Debug multithreaded executable file using LIBCMTD.lib.
+)
+
+  #================#
+  #    GCC flags   #
+  #================#
+
+set(gcc_common
+  -pthread
+  -pipe       # Faster compiler processing
+  # Adds flag only to C++
+  "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-pedantic>" # Turn on warnings about constructs/situations that may be non-portable or outside of the standard
+  -Wall       # Turn on warnings
+  -Wextra     # Turn on warnings
+  -Werror     # Turn warnings into errors
+  "$<$<BOOL:UNIX>:-fPIC>"
+)
+set(gcc_release
+  "${gcc_common}"
+  -fno-stack-protector  # Produces debugging information specifically for gdb
+)
+set(gcc_debug
+  "${gcc_common}"
+  -ggdb
+  -ffloat-store     # Improve debug run solution stability
+  -fsignaling-nans  # Disable optimizations that may have concealed NaN behavior
+  -D_GLIBCXX_DEBUG  # Standard container debug mode (bounds checking, ...)
+)
+
+  #================#
+  #  Clang flags   #
+  #================#
+
+set(clang_common
+  -pipe       # Faster compiler processing
+  # Adds flag only to C++
+  "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-pedantic>" # Turn on warnings about constructs/situations that may be non-portable or outside of the standard
+  -Wall       # Turn on warnings
+  -Wextra     # Turn on warnings
+  -Werror     # Turn warnings into errors
+)
+set(clang_release
+  "${clang_common}"
+  -fno-stack-protector  # Produces debugging information specifically for gdb
+)
+set(clang_debug
+  "${clang_common}"
+  -ggdb
+  -ffloat-store     # Improve debug run solution stability
+  -fsignaling-nans  # Disable optimizations that may have concealed NaN behavior
+  -D_GLIBCXX_DEBUG  # Standard container debug mode (bounds checking, ...)
+)
+
+  #===================#
+  # Win32 Intel flags #
+  #===================#
+
+set(win32_intel_common
+  /nologo         # Skip banner text
+  /Qcxx-features  # Enables standard C++ features without disabling Microsoft extensions
+  /Wall           # Enable "all" warnings
+  /DNOMINMAX      # Avoid build errors due to STL/Windows min-max conflicts
+  /DWIN32_LEAN_AND_MEAN # Excludes rarely used services and headers from compilation
+)
+set(win32_intel_release
+  "${win32_intel_common}"
+  /O3           # Agressive optimization
+  /Qprec-div-   # Faster division
+  /Qansi-alias  # Better optimization via strict aliasing rules
+  /Qip          # Inter-procedural optimnization within a single file
+  /Qinline-factor:225 # Aggressive inlining
+  # /fp:fast=2  # Aggressive optimizations on floating-point data
+)
+set(win32_intel_debug
+  "${win32_intel_common}"
+  /fp:source      # Use source-specified floating point precision
+  /Qtrapuv        # Initialize local variables to unusual values to help detect use uninitialized
+  /check:stack,uninit # Enables runtime checking of the stack (buffer over and underruns; pointer verification) and uninitialized variables
+  /Gs0            # Enable stack checking for all functions
+  /GS             # Buffer overrun detection
+  /Qfp-stack-check  # Tells the compiler to generate extra code after every function call to ensure fp stack is as expected
+  /traceback      # Enables traceback on error
+)
+
+  #==================#
+  # Unix Intel flags #
+  #==================#
+
+set(unix_intel_common
+  # COMPILER FLAGS
+  -Wall       # Enable "all" warnings
+  # Not apple
+  "$<$<NOT:${APPLE}>:-pthreat"
+>
+)
+set(unix_intel_release
+  "${unix_intel_common}"
+  -O3           # Agressive optimization
+  # -Ofast # More aggressive optimizations (instead of -O3) (enables -no-prec-div and -fp-model fast=2)
+  -no-prec-div  # Faster division (enabled by -Ofast)
+  -ansi-alias   # Enables more aggressive optimizations on floating-point data
+  -ip           # Enables inter-procedural optimnization within a single file
+  -inline-factor=225 # Enables more aggressive inlining
+)
+set(unix_intel_debug
+  "${unix_intel_common}"
+  -strict-ansi      # Strict language conformance: Performance impact so limit to debug build
+  -fp-model source  # Use source-specified floating point precision
+  -ftrapuv          # Initialize local variables to unusual values to help detect use uninitialized
+  -check=stack,uninit # Enables runtime checking of the stack (buffer over and underruns; pointer verification) and uninitialized variables
+  -fstack-security-check # Buffer overrun detection
+  -fp-stack-check   # Check the floating point stack after every function call
+  -traceback        # Enables traceback on error
+)
 
   #================#
   # Compiler flags #
   #================#
 
-target_compile_options(penumbra_common_interface INTERFACE
-  $<$<CXX_COMPILER_ID:MSVC>: # Visual C++ (VS 2013)
-    /nologo
-    /EHsc
-    /W4
-    /WX
-    $<$<CONFIG:Release>:
-      /GS-    # Disable buffer overrun checks for performance in release mode
-      /MT     # Causes the application to use the multithread, static version of the run-time library, using LIBCMT.lib.
-    >
-    $<$<CONFIG:Debug>:
-      /Zi     #
-      /Ob0    # Disable inlining
-      /Od     # Turns off all optimizations in the program and speeds compilation
-      /RTC1   # Runtime checks
-      /MTd    # Debug multithreaded executable file using LIBCMTD.lib.
-    >
-  >
-  # GCC
-  $<$<CXX_COMPILER_ID:GNU>:
-    -pthread
-    -pipe       # Faster compiler processing
-    $<$<COMPILE_LANG_AND_ID:CXX,GNU>: # Adds flag only to C++
-      -pedantic   # Turn on warnings about constructs/situations that may be non-portable or outside of the standard
-    >
-    -Wall       # Turn on warnings
-    -Wextra     # Turn on warnings
-    -Werror     # Turn warnings into errors
-    $<$<CONFIG:Release>:
-      -fno-stack-protector  # Produces debugging information specifically for gdb
-    >
-    $<$<CONFIG:Debug>:
-      -ggdb
-      -ffloat-store     # Improve debug run solution stability
-      -fsignaling-nans  # Disable optimizations that may have concealed NaN behavior
-      -D_GLIBCXX_DEBUG  # Standard container debug mode (bounds checking, ...)
-    >
-    # -finline-limit=2000 # More aggressive inlining   This is causing unit test failures on Ubuntu 14.04
-    $<$<BOOL:UNIX>:
-      -fPIC
-    >
-  >
-  $<$<CXX_COMPILER_ID:Clang>:
-    -pipe       # Faster compiler processing
-    -pedantic   # Turn on warnings about constructs/situations that may be non-portable or outside of the standard
-    -Wall       # Turn on warnings
-    -Wextra     # Turn on warnings
-    -Werror     # Turn warnings into errors
-    $<$<CONFIG:Release>:
-      -fno-stack-protector  # Produces debugging information specifically for gdb
-    >
-    $<$<CONFIG:Debug>:
-      -ggdb
-      -ffloat-store     # Improve debug run solution stability
-      -fsignaling-nans  # Disable optimizations that may have concealed NaN behavior
-      -D_GLIBCXX_DEBUG  # Standard container debug mode (bounds checking, ...)
-    >
-  >
-
-  $<$<BOOL:${WIN32}>: $<$<CXX_COMPILER_ID:Intel>:
-      /nologo         # Skip banner text
-      /Qcxx-features  # Enables standard C++ features without disabling Microsoft extensions
-      /Wall           # Enable "all" warnings
-      /DNOMINMAX      # Avoid build errors due to STL/Windows min-max conflicts
-      /DWIN32_LEAN_AND_MEAN # Excludes rarely used services and headers from compilation
-      $<$<CONFIG:Release>: # ADDITIONAL RELEASE-MODE-SPECIFIC FLAGS
-        /O3           # Agressive optimization
-        /Qprec-div-   # Faster division
-        /Qansi-alias  # Better optimization via strict aliasing rules
-        /Qip          # Inter-procedural optimnization within a single file
-        /Qinline-factor:225 # Aggressive inlining
-        # /fp:fast=2  # Aggressive optimizations on floating-point data
-      >
-      $<$<CONFIG:Debug>:  # ADDITIONAL DEBUG-MODE-SPECIFIC FLAGS
-        /fp:source      # Use source-specified floating point precision
-        /Qtrapuv        # Initialize local variables to unusual values to help detect use uninitialized
-        /check:stack,uninit # Enables runtime checking of the stack (buffer over and underruns; pointer verification) and uninitialized variables
-        /Gs0            # Enable stack checking for all functions
-        /GS             # Buffer overrun detection
-        /Qfp-stack-check  # Tells the compiler to generate extra code after every function call to ensure fp stack is as expected
-        /traceback      # Enables traceback on error
-      >
-    >
-  >
-  $<$<BOOL: UNIX>: $<$<CXX_COMPILER_ID:Intel>:
-
-    # COMPILER FLAGS
-    -Wall       # Enable "all" warnings
-
-    # Not apple
-    $<$<NOT:"${APPLE}">:
-      -pthreat
-    >
-    
-    $<$<CONFIG:Release>:    # ADDITIONAL RELEASE-MODE-SPECIFIC FLAGS
-      -O3           # Agressive optimization
-      # -Ofast # More aggressive optimizations (instead of -O3) (enables -no-prec-div and -fp-model fast=2)
-      -no-prec-div  # Faster division (enabled by -Ofast)
-      -ansi-alias   # Enables more aggressive optimizations on floating-point data
-      -ip           # Enables inter-procedural optimnization within a single file
-      -inline-factor=225 # Enables more aggressive inlining
-    >
-    $<$<CONFIG:Debug>:    # ADDITIONAL DEBUG-MODE-SPECIFIC FLAGS
-      -strict-ansi      # Strict language conformance: Performance impact so limit to debug build
-      -fp-model source  # Use source-specified floating point precision
-      -ftrapuv          # Initialize local variables to unusual values to help detect use uninitialized
-      -check=stack,uninit # Enables runtime checking of the stack (buffer over and underruns; pointer verification) and uninitialized variables
-      -fstack-security-check # Buffer overrun detection
-      -fp-stack-check   # Check the floating point stack after every function call
-      -traceback        # Enables traceback on error
-
-    >
-  >
-  >
-)
+  target_compile_options(penumbra_common_interface INTERFACE
+    "$<${use_msvc_release}:${msvc_release}>"
+    "$<${use_msvc_debug}:${msvc_debug}>"
+    "$<${use_gcc_release}:${gcc_release}>"
+    "$<${use_gcc_debug}:${gcc_debug}>"
+    "$<${use_gcc_release}:${gcc_release}>"
+    "$<${use_gcc_debug}:${gcc_debug}>"
+    "$<${use_clang_release}:${clang_release}>"
+    "$<${use_clang_debug}:${clang_debug}>"
+    "$<${use_win32_intel_release}:${win32_intel_release}>"
+    "$<${use_win32_intel_debug}:${win32_intel_debug}>"
+    "$<${use_unix_intel_release}:${unix_intel_release}>"
+    "$<${use_unix_intel_debug}:${unix_intel_debug}>"
+  )
 
   #================#
   #  Linker flags  #
   #================#
 
 target_link_options(penumbra_common_interface INTERFACE 
-  $<$<CXX_COMPILER_ID:GNU>:
-    -pthread
-  >
-
+  "$<$<CXX_COMPILER_ID:GNU>:-pthread>"
 )
+#file(GENERATE OUTPUT hola.txt CONTENT "$<${CXX_COMPILER_ID}:MSVC>")

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -40,12 +40,26 @@ target_include_directories(tess2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Inc
 target_include_directories(tess2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source)
 
 target_compile_options(tess2 PRIVATE
+          $<$<CXX_COMPILER_ID:MSVC>: # supresses the following warnings for tess2
+            /wd4100
+            /wd4324
+          >
           $<$<CXX_COMPILER_ID:GNU>: # supresses the following warnings for tess2
-            -Wno-clobbered>)
+            -Wno-clobbered>
+)
 
 target_compile_options(glfw PRIVATE
+          $<$<CXX_COMPILER_ID:MSVC>: # supresses the following warnings for glfw
+            /wd4100
+            /wd4324
+            /wd4152
+            /wd4201
+            /wd4244
+          >
           $<$<CXX_COMPILER_ID:GNU>: # supresses the following warnings for glfw
-            -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare>)
+            -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare
+          >
+          )
 
 # googletest library
 if (${PROJECT_NAME}_BUILD_TESTING AND NOT TARGET gtest)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -39,24 +39,24 @@ add_library(tess2 ${libtess2_sources})
 target_include_directories(tess2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Include)
 target_include_directories(tess2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source)
 
-target_compile_options(tess2 PRIVATE
-          $<$<CXX_COMPILER_ID:MSVC>: # supresses the following warnings for tess2
-            /wd4100
-            /wd4324
+target_compile_options(tess2 PRIVATE    # supresses the following warnings for tess2
+          $<$<CXX_COMPILER_ID:MSVC>:
+            /wd4100   # Unreferenced formal paramenter
+            /wd4324   # structure was padded due to alignment specifier
           >
-          $<$<CXX_COMPILER_ID:GNU>: # supresses the following warnings for tess2
-            -Wno-clobbered>
+          $<$<CXX_COMPILER_ID:GNU>:
+            -Wno-clobbered
+          >
 )
 
-target_compile_options(glfw PRIVATE
-          $<$<CXX_COMPILER_ID:MSVC>: # supresses the following warnings for glfw
-            /wd4100
-            /wd4324
-            /wd4152
-            /wd4201
-            /wd4244
+target_compile_options(glfw PRIVATE   # supresses the following warnings for glfw
+          $<$<CXX_COMPILER_ID:MSVC>:
+            /wd4100   # Unreferenced formal paramenter
+            /wd4152   # Non standard extension
+            /wd4201   # Nonstandard extension used
+            /wd4244   # Conversion creates possible loss of data
           >
-          $<$<CXX_COMPILER_ID:GNU>: # supresses the following warnings for glfw
+          $<$<CXX_COMPILER_ID:GNU>:
             -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare
           >
           )

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -40,10 +40,6 @@ target_include_directories(tess2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Inc
 target_include_directories(tess2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source)
 
 target_compile_options(tess2 PRIVATE    # supresses the following warnings for tess2
-          $<$<CXX_COMPILER_ID:MSVC>:
-            /wd4100   # Unreferenced formal paramenter
-            /wd4324   # structure was padded due to alignment specifier
-          >
           $<$<CXX_COMPILER_ID:GNU>:
             -Wno-clobbered
           >
@@ -57,7 +53,9 @@ target_compile_options(glfw PRIVATE   # supresses the following warnings for glf
             /wd4244   # Conversion creates possible loss of data
           >
           $<$<CXX_COMPILER_ID:GNU>:
-            -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare
+            -Wno-unused-parameter
+            -Wno-missing-field-initializers
+            -Wno-sign-compare
           >
           )
 


### PR DESCRIPTION
Moves the MT flag used for multithread executable to only be used in the release version, and adds MTd, similar to the MT flag but used for debugging, to debug configurations. 