### PR TITLE
Clean up compiler flags

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ matrix.os }}-${{ matrix.os_ver }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v2.5
       - name: Set Project Name
         run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
       - name: Create Build Directory
@@ -108,7 +108,7 @@ jobs:
           mklink libglapi.dll "x64\libglapi.dll"
         working-directory: build\test\${{ matrix.config }}
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
+        uses: GabrielBB/xvfb-action@v1.6
         with:
           run: ctest -C ${{ matrix.config }} --output-on-failure
           working-directory: build
@@ -118,4 +118,4 @@ jobs:
         working-directory: build
       - name: Upload Code Coverage Report
         if: matrix.coverage == 'ON'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,11 +32,27 @@ jobs:
             static_lib: ON
             coverage: OFF
             examples: ON
+          - os: windows
+            os_ver: "2022"
+            cc: cl
+            cxx: cl
+            config: Debug
+            static_lib: ON
+            coverage: OFF
+            examples: ON
           - os: macos
             os_ver: "12"
             cc: clang
             cxx: clang++
             config: Release
+            static_lib: ON
+            coverage: OFF
+            examples: ON
+          - os: macos
+            os_ver: "12"
+            cc: clang
+            cxx: clang++
+            config: Debug
             static_lib: ON
             coverage: OFF
             examples: ON

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ${{ matrix.os }}-${{ matrix.os_ver }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.5
+        uses: actions/checkout@v3
       - name: Set Project Name
         run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
       - name: Create Build Directory

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,40 +7,52 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: []
-        os_ver: []
-        cc: []
-        cxx: []
         include:
-          - config: Release
-            static_lib: ON
-            coverage: OFF
-            examples: ON
           - os: ubuntu
             os_ver: "22.04"
             cc: gcc-11
             cxx: g++-11
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            examples: ON
           - os: ubuntu
             os_ver: "20.04"
             cc: gcc-10
             cxx: g++-10
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            examples: ON
           - os: windows
             os_ver: "2022"
             cc: cl
             cxx: cl
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            examples: ON
           - os: macos
             os_ver: "12"
             cc: clang
             cxx: clang++
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            examples: ON
           - os: macos
             os_ver: "11"
             cc: clang
             cxx: clang++
+            config: Release
+            static_lib: ON
+            coverage: OFF
+            examples: ON
           - os: ubuntu
             os_ver: "20.04"
-            config: Debug
             cc: gcc-10
             cxx: g++-10
+            config: Debug
             static_lib: OFF
             coverage: ON
             examples: OFF

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,49 +7,39 @@ jobs:
     name: Build
     strategy:
       matrix:
+        config: [Release]
+        static_lib: [ON]
+        coverage: [OFF]
+        examples: [ON]
         include:
           - os: ubuntu
             os_ver: "22.04"
-            config: Release
-            static_lib: ON
-            coverage: OFF
             cc: gcc-11
             cxx: g++-11
           - os: ubuntu
             os_ver: "20.04"
-            config: Release
-            static_lib: ON
-            coverage: OFF
             cc: gcc-10
             cxx: g++-10
           - os: windows
             os_ver: "2022"
-            config: Release
-            static_lib: ON
-            coverage: OFF
             cc: cl
             cxx: cl
           - os: macos
             os_ver: "12"
-            config: Release
-            static_lib: ON
-            coverage: OFF
             cc: clang
             cxx: clang++
           - os: macos
             os_ver: "11"
-            config: Release
-            static_lib: ON
-            coverage: OFF
             cc: clang
             cxx: clang++
           - os: ubuntu
             os_ver: "20.04"
             config: Debug
-            static_lib: OFF
-            coverage: ON
             cc: gcc-10
             cxx: g++-10
+            static_lib: OFF
+            coverage: ON
+            examples: OFF
       fail-fast: false
     defaults:
       run:
@@ -69,7 +59,7 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get -y install xorg-dev libgl1-mesa-dev
       - name: Configure CMake
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -D${{ env.REPOSITORY_NAME }}_BUILD_TESTING="ON" -D${{ env.REPOSITORY_NAME }}_STATIC_LIB="${{ matrix.static_lib }}" -D${{ env.REPOSITORY_NAME }}_COVERAGE="${{ matrix.coverage }}"
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE="${{ matrix.config }}" -D${{ env.REPOSITORY_NAME }}_BUILD_TESTING="ON" -D${{ env.REPOSITORY_NAME }}_STATIC_LIB="${{ matrix.static_lib }}" -D${{ env.REPOSITORY_NAME }}_COVERAGE="${{ matrix.coverage }}" -D${{ env.REPOSITORY_NAME }}_BUILD_EXAMPLES="${{ matrix.examples }}"
       - name: Build
         run: cmake --build build --config ${{ matrix.config }}
       - name: Download Mesa3D on Windows

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,10 @@ jobs:
     name: Build
     strategy:
       matrix:
-        os: [ubuntu, windows, macos]
+        os: []
+        os_ver: []
+        cc: []
+        cxx: []
         include:
           - config: Release
             static_lib: ON

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,11 +7,12 @@ jobs:
     name: Build
     strategy:
       matrix:
-        config: [Release]
-        static_lib: [ON]
-        coverage: [OFF]
-        examples: [ON]
+        os: [ubuntu, windows, macos]
         include:
+          - config: Release
+            static_lib: ON
+            coverage: OFF
+            examples: ON
           - os: ubuntu
             os_ver: "22.04"
             cc: gcc-11

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
-project(penumbra)
+project(penumbra LANGUAGES CXX C)
 
 cmake_policy(SET CMP0079 NEW) # target_link_libraries() allows use with targets in other directories.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.7)
+cmake_policy(SET CMP0091 NEW)
 project(penumbra LANGUAGES CXX C)
 
 cmake_policy(SET CMP0079 NEW) # target_link_libraries() allows use with targets in other directories.

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -1,22 +1,17 @@
 # Empty default flags
-set(CMAKE_C_FLAGS "")
 set(CMAKE_CXX_FLAGS "")
 set(CMAKE_CXX_FLAGS_RELEASE "")
 set(CMAKE_CXX_FLAGS_DEBUG "")
-set(CMAKE_EXE_LINKER_FLAGS "")
-set(CMAKE_EXE_LINKER_FLAGS_RELEASE "")
-set(CMAKE_EXE_LINKER_FLAGS_DEBUG "")
+
 
 add_library(penumbra_common_interface INTERFACE)
 
-  #================#
-  # Compiler flags #
-  #================#
+  #==================#
+  # Compiler options #
+  #==================#
 
 target_compile_options(penumbra_common_interface INTERFACE
   $<$<CXX_COMPILER_ID:MSVC>: # Visual C++ (VS 2013)
-    /DWIN32
-    /D_WINDOWS
     /GR
     /nologo
     /EHsc
@@ -48,13 +43,13 @@ target_compile_options(penumbra_common_interface INTERFACE
     $<$<CONFIG:Release>:
       -fno-stack-protector  # Produces debugging information specifically for gdb
       -O3
-      -DNDEBUG
     >
-    $<$<CONFIG:Debug>:
-      -ggdb
-      -ffloat-store     # Improve debug run solution stability
-      -fsignaling-nans  # Disable optimizations that may have concealed NaN behavior
-      -D_GLIBCXX_DEBUG  # Standard container debug mode (bounds checking, ...)
+    $<$<CXX_COMPILER_ID:GNU>:
+      $<$<CONFIG:Debug>:
+        -ggdb
+        -ffloat-store     # Improve debug run solution stability
+        -fsignaling-nans  # Disable optimizations that may have concealed NaN behavior
+      >
     >
     # -finline-limit=2000 # More aggressive inlining   This is causing unit test failures on Ubuntu 14.04
     $<$<BOOL:UNIX>:
@@ -63,9 +58,29 @@ target_compile_options(penumbra_common_interface INTERFACE
   >
 )
 
-  #================#
-  #  Linker flags  #
-  #================#
+#======================#
+# Compiler definitions #
+#======================#
+
+target_compile_definitions(penumbra_common_interface INTERFACE
+  $<$<CXX_COMPILER_ID:MSVC>: # Visual C++ (VS 2013)
+    WIN32
+    _WINDOWS
+  >
+  $<$<CONFIG:Release>:
+    NDEBUG
+  >
+  # GCC
+  $<$<CXX_COMPILER_ID:GNU>:
+    $<$<CONFIG:Debug>:
+      _GLIBCXX_DEBUG  # Standard container debug mode (bounds checking, ...)
+    >
+  >
+)
+
+#==================#
+#  Linker options  #
+#==================#
 
 target_link_options(penumbra_common_interface INTERFACE
   $<$<CXX_COMPILER_ID:GNU>:

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -31,7 +31,7 @@ target_compile_options(penumbra_common_interface INTERFACE
     >
   >
   # GCC
-  $<$<CXX_COMPILER_ID:GNU>:
+  $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:
     -pthread
     -pipe       # Faster compiler processing
     $<$<COMPILE_LANG_AND_ID:CXX,GNU>: # Adds flag only to C++
@@ -54,23 +54,6 @@ target_compile_options(penumbra_common_interface INTERFACE
       -fPIC
     >
   >
-  $<$<CXX_COMPILER_ID:Clang>:
-    -pipe       # Faster compiler processing
-    -pedantic   # Turn on warnings about constructs/situations that may be non-portable or outside of the standard
-    -Wall       # Turn on warnings
-    -Wextra     # Turn on warnings
-    -Werror     # Turn warnings into errors
-    $<$<CONFIG:Release>:
-      -fno-stack-protector  # Produces debugging information specifically for gdb
-    >
-    $<$<CONFIG:Debug>:
-      -ggdb
-      -ffloat-store     # Improve debug run solution stability
-      -fsignaling-nans  # Disable optimizations that may have concealed NaN behavior
-      -D_GLIBCXX_DEBUG  # Standard container debug mode (bounds checking, ...)
-    >
-  >
-
   $<$<BOOL:${WIN32}>: $<$<CXX_COMPILER_ID:Intel>:
       /nologo         # Skip banner text
       /Qcxx-features  # Enables standard C++ features without disabling Microsoft extensions
@@ -105,7 +88,7 @@ target_compile_options(penumbra_common_interface INTERFACE
     $<$<NOT:"${APPLE}">:
       -pthreat
     >
-    
+
     $<$<CONFIG:Release>:    # ADDITIONAL RELEASE-MODE-SPECIFIC FLAGS
       -O3           # Agressive optimization
       # -Ofast # More aggressive optimizations (instead of -O3) (enables -no-prec-div and -fp-model fast=2)
@@ -132,7 +115,7 @@ target_compile_options(penumbra_common_interface INTERFACE
   #  Linker flags  #
   #================#
 
-target_link_options(penumbra_common_interface INTERFACE 
+target_link_options(penumbra_common_interface INTERFACE
   $<$<CXX_COMPILER_ID:GNU>:
     -pthread
   >

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -20,7 +20,7 @@ target_compile_options(penumbra_common_interface INTERFACE
     /GR
     /nologo
     /EHsc
-    /W3
+    /W4
     /WX
     $<$<CONFIG:Release>:
       /GS-    # Disable buffer overrun checks for performance in release mode

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -17,17 +17,18 @@ target_compile_options(penumbra_common_interface INTERFACE
   $<$<CXX_COMPILER_ID:MSVC>: # Visual C++ (VS 2013)
     /nologo
     /EHsc
-    /MT
     /W3
     /WX
     $<$<CONFIG:Release>:
       /GS-    # Disable buffer overrun checks for performance in release mode
+      /MT
     >
     $<$<CONFIG:Debug>:
       /Zi     #
       /Ob0    # Disable inlining
       /Od     # Turns off all optimizations in the program and speeds compilation
       /RTC1   # Runtime checks
+      /MTd
     >
   >
   # GCC

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -15,12 +15,18 @@ add_library(penumbra_common_interface INTERFACE)
 
 target_compile_options(penumbra_common_interface INTERFACE
   $<$<CXX_COMPILER_ID:MSVC>: # Visual C++ (VS 2013)
+    /DWIN32
+    /D_WINDOWS
+    /GR
     /nologo
     /EHsc
     /W3
     /WX
     $<$<CONFIG:Release>:
       /GS-    # Disable buffer overrun checks for performance in release mode
+      /O2
+      /Ob2
+      /DNDEBUG
     >
     $<$<CONFIG:Debug>:
       /Zi     #
@@ -41,6 +47,8 @@ target_compile_options(penumbra_common_interface INTERFACE
     -Werror     # Turn warnings into errors
     $<$<CONFIG:Release>:
       -fno-stack-protector  # Produces debugging information specifically for gdb
+      -O3
+      -DNDEBUG
     >
     $<$<CONFIG:Debug>:
       -ggdb

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -85,7 +85,7 @@ target_compile_options(penumbra_common_interface INTERFACE
 
     # Not apple
     $<$<NOT:"${APPLE}">:
-      -pthreat
+      -pthread
     >
 
     $<$<CONFIG:Release>:    # ADDITIONAL RELEASE-MODE-SPECIFIC FLAGS

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -29,7 +29,7 @@ target_compile_options(penumbra_common_interface INTERFACE
       /RTC1   # Runtime checks
     >
   >
-  # GCC
+  # GCC And Clang
   $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:
     -pthread
     -pipe       # Faster compiler processing
@@ -52,61 +52,6 @@ target_compile_options(penumbra_common_interface INTERFACE
     $<$<BOOL:UNIX>:
       -fPIC
     >
-  >
-  $<$<BOOL:${WIN32}>: $<$<CXX_COMPILER_ID:Intel>:
-      /nologo         # Skip banner text
-      /Qcxx-features  # Enables standard C++ features without disabling Microsoft extensions
-      /Wall           # Enable "all" warnings
-      /DNOMINMAX      # Avoid build errors due to STL/Windows min-max conflicts
-      /DWIN32_LEAN_AND_MEAN # Excludes rarely used services and headers from compilation
-      $<$<CONFIG:Release>: # ADDITIONAL RELEASE-MODE-SPECIFIC FLAGS
-        /O3           # Agressive optimization
-        /Qprec-div-   # Faster division
-        /Qansi-alias  # Better optimization via strict aliasing rules
-        /Qip          # Inter-procedural optimnization within a single file
-        /Qinline-factor:225 # Aggressive inlining
-        # /fp:fast=2  # Aggressive optimizations on floating-point data
-      >
-      $<$<CONFIG:Debug>:  # ADDITIONAL DEBUG-MODE-SPECIFIC FLAGS
-        /fp:source      # Use source-specified floating point precision
-        /Qtrapuv        # Initialize local variables to unusual values to help detect use uninitialized
-        /check:stack,uninit # Enables runtime checking of the stack (buffer over and underruns; pointer verification) and uninitialized variables
-        /Gs0            # Enable stack checking for all functions
-        /GS             # Buffer overrun detection
-        /Qfp-stack-check  # Tells the compiler to generate extra code after every function call to ensure fp stack is as expected
-        /traceback      # Enables traceback on error
-      >
-    >
-  >
-  $<$<BOOL: UNIX>: $<$<CXX_COMPILER_ID:Intel>:
-
-    # COMPILER FLAGS
-    -Wall       # Enable "all" warnings
-
-    # Not apple
-    $<$<NOT:"${APPLE}">:
-      -pthreat
-    >
-
-    $<$<CONFIG:Release>:    # ADDITIONAL RELEASE-MODE-SPECIFIC FLAGS
-      -O3           # Agressive optimization
-      # -Ofast # More aggressive optimizations (instead of -O3) (enables -no-prec-div and -fp-model fast=2)
-      -no-prec-div  # Faster division (enabled by -Ofast)
-      -ansi-alias   # Enables more aggressive optimizations on floating-point data
-      -ip           # Enables inter-procedural optimnization within a single file
-      -inline-factor=225 # Enables more aggressive inlining
-    >
-    $<$<CONFIG:Debug>:    # ADDITIONAL DEBUG-MODE-SPECIFIC FLAGS
-      -strict-ansi      # Strict language conformance: Performance impact so limit to debug build
-      -fp-model source  # Use source-specified floating point precision
-      -ftrapuv          # Initialize local variables to unusual values to help detect use uninitialized
-      -check=stack,uninit # Enables runtime checking of the stack (buffer over and underruns; pointer verification) and uninitialized variables
-      -fstack-security-check # Buffer overrun detection
-      -fp-stack-check   # Check the floating point stack after every function call
-      -traceback        # Enables traceback on error
-
-    >
-  >
   >
 )
 

--- a/cmake/compiler-flags.cmake
+++ b/cmake/compiler-flags.cmake
@@ -21,14 +21,12 @@ target_compile_options(penumbra_common_interface INTERFACE
     /WX
     $<$<CONFIG:Release>:
       /GS-    # Disable buffer overrun checks for performance in release mode
-      /MT
     >
     $<$<CONFIG:Debug>:
       /Zi     #
       /Ob0    # Disable inlining
       /Od     # Turns off all optimizations in the program and speeds compilation
       /RTC1   # Runtime checks
-      /MTd
     >
   >
   # GCC

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,8 +11,8 @@ elseif (APPLE)
 endif()
 
 add_executable(awning WIN32 MACOSX_BUNDLE awning.cpp ${ICON})
-
-target_link_libraries(awning ${PROJECT_NAME})
+target_link_libraries(awning PRIVATE ${PROJECT_NAME} penumbra_common_interface)
+target_compile_features(awning PRIVATE cxx_std_17)
 
 set(EXE_BINARIES awning)
 
@@ -34,4 +34,3 @@ if (APPLE)
                           MACOSX_BUNDLE_LONG_VERSION_STRING "0"
                           MACOSX_BUNDLE_ICON_FILE glfw.icns )
 endif()
-target_link_libraries(awning PRIVATE penumbra_common_interface)

--- a/examples/awning.cpp
+++ b/examples/awning.cpp
@@ -40,7 +40,7 @@ int main(void) {
 
   unsigned wallId = pumbra.addSurface(wall);
   unsigned windowId = pumbra.addSurface(window);
-  unsigned awningId = pumbra.addSurface(awning);
+  /*unsigned awningId = */ pumbra.addSurface(awning);
 
   pumbra.setModel();
   pumbra.setSunPosition(2.50f, 0.3f);
@@ -63,7 +63,7 @@ int main(void) {
   Pumbra::Surface fin(finVerts);
 
   windowId = pumbra.addSurface(window);
-  awningId = pumbra.addSurface(awning);
+  /*awningId = */ pumbra.addSurface(awning);
   /*unsigned finID = */ pumbra.addSurface(fin);
 
   pumbra.setModel();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,10 @@ generate_export_header(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE glad glfw tess2 penumbra_common_interface)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+# If MSVC_RUNTIME_LIBRARY is not by a parent project use the default.
+# It's not clear why this is needed, since documentation indicates it
+#   should be happening with the CMP0091 policy set to NEW.
 get_target_property(RTL ${PROJECT_NAME} MSVC_RUNTIME_LIBRARY)
 if ("${RTL}" STREQUAL "RTL-NOTFOUND")
   set_target_properties(${PROJECT_NAME} PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,17 +19,16 @@ else()
   add_library(${PROJECT_NAME} SHARED ${library_sources})
 endif()
 
-target_include_directories(${PROJECT_NAME} PUBLIC
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
   ${PROJECT_SOURCE_DIR}/include
+  PRIVATE
   ${PROJECT_SOURCE_DIR}/src
 )
 
 include(GenerateExportHeader)
 generate_export_header(${PROJECT_NAME})
 
-target_link_libraries(tess2 PRIVATE penumbra_common_interface)
-target_link_libraries(glad PRIVATE penumbra_common_interface)
-target_link_libraries(glfw PRIVATE penumbra_common_interface)
 target_link_libraries(${PROJECT_NAME} PRIVATE glad glfw tess2 penumbra_common_interface)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,10 @@ generate_export_header(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE glad glfw tess2 penumbra_common_interface)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+get_target_property(RTL ${PROJECT_NAME} MSVC_RUNTIME_LIBRARY)
+if ("${RTL}" STREQUAL "RTL-NOTFOUND")
+  set_target_properties(${PROJECT_NAME} PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+endif()
 
 if (${PROJECT_NAME}_COVERAGE)
   add_coverage(${PROJECT_NAME})

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -31,14 +31,6 @@ target_include_directories(glfw PUBLIC
  ${PROJECT_SOURCE_DIR}/vendor/glfw/deps
 )
 target_compile_options(glfw PRIVATE
-  $<$<C_COMPILER_ID:MSVC>: # suppresses the following warnings for glfw
-    $<$<CONFIG:Release>:
-      /MT
-    >
-    $<$<CONFIG:Debug>:
-      /MTd
-    >
-  >
   $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for glfw
     -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare
   >
@@ -52,14 +44,6 @@ add_library(tess2 ${libtess2_sources})
 target_include_directories(tess2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Include)
 target_include_directories(tess2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source)
 target_compile_options(tess2 PRIVATE
-  $<$<C_COMPILER_ID:MSVC>: # suppresses the following warnings for glfw
-    $<$<CONFIG:Release>:
-      /MT
-    >
-    $<$<CONFIG:Debug>:
-      /MTd
-    >
-  >
   $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for tess2
     -Wno-clobbered
   >

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -30,11 +30,11 @@ target_include_directories(glfw PUBLIC
  ${PROJECT_SOURCE_DIR}/vendor/glfw/include
  ${PROJECT_SOURCE_DIR}/vendor/glfw/deps
 )
-target_compile_options(glfw PRIVATE
-  $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for glfw
-    -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare
-  >
-)
+#target_compile_options(glfw PRIVATE
+#  $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for glfw
+#    -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare
+#  >
+#)
 
 # tess2 library
 file(GLOB libtess2_sources "${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source/[a-zA-Z]*.c")
@@ -43,11 +43,11 @@ add_library(tess2 ${libtess2_sources})
 
 target_include_directories(tess2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Include)
 target_include_directories(tess2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source)
-target_compile_options(tess2 PRIVATE
-  $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for tess2
-    -Wno-clobbered
-  >
-)
+#target_compile_options(tess2 PRIVATE
+#  $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for tess2
+#    -Wno-clobbered
+#  >
+#)
 
 # googletest library
 if (${PROJECT_NAME}_BUILD_TESTING AND NOT TARGET gtest)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -31,8 +31,18 @@ target_include_directories(glfw PUBLIC
  ${PROJECT_SOURCE_DIR}/vendor/glfw/deps
 )
 target_compile_options(glfw PRIVATE
+  $<$<C_COMPILER_ID:MSVC>: # suppresses the following warnings for glfw
+    $<$<CONFIG:Release>:
+      /MT
+    >
+    $<$<CONFIG:Debug>:
+      /MTd
+    >
+  >
   $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for glfw
-  -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare>)
+    -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare
+  >
+)
 
 # tess2 library
 file(GLOB libtess2_sources "${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source/[a-zA-Z]*.c")
@@ -42,8 +52,18 @@ add_library(tess2 ${libtess2_sources})
 target_include_directories(tess2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Include)
 target_include_directories(tess2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source)
 target_compile_options(tess2 PRIVATE
-          $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for tess2
-            -Wno-clobbered>)
+  $<$<C_COMPILER_ID:MSVC>: # suppresses the following warnings for glfw
+    $<$<CONFIG:Release>:
+      /MT
+    >
+    $<$<CONFIG:Debug>:
+      /MTd
+    >
+  >
+  $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for tess2
+    -Wno-clobbered
+  >
+)
 
 # googletest library
 if (${PROJECT_NAME}_BUILD_TESTING AND NOT TARGET gtest)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -30,11 +30,6 @@ target_include_directories(glfw PUBLIC
  ${PROJECT_SOURCE_DIR}/vendor/glfw/include
  ${PROJECT_SOURCE_DIR}/vendor/glfw/deps
 )
-#target_compile_options(glfw PRIVATE
-#  $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for glfw
-#    -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare
-#  >
-#)
 
 # tess2 library
 file(GLOB libtess2_sources "${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source/[a-zA-Z]*.c")
@@ -43,11 +38,6 @@ add_library(tess2 ${libtess2_sources})
 
 target_include_directories(tess2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Include)
 target_include_directories(tess2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source)
-#target_compile_options(tess2 PRIVATE
-#  $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for tess2
-#    -Wno-clobbered
-#  >
-#)
 
 # googletest library
 if (${PROJECT_NAME}_BUILD_TESTING AND NOT TARGET gtest)

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -30,6 +30,9 @@ target_include_directories(glfw PUBLIC
  ${PROJECT_SOURCE_DIR}/vendor/glfw/include
  ${PROJECT_SOURCE_DIR}/vendor/glfw/deps
 )
+target_compile_options(glfw PRIVATE
+  $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for glfw
+  -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare>)
 
 # tess2 library
 file(GLOB libtess2_sources "${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source/[a-zA-Z]*.c")
@@ -38,14 +41,9 @@ add_library(tess2 ${libtess2_sources})
 
 target_include_directories(tess2 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Include)
 target_include_directories(tess2 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libtess2/Source)
-
 target_compile_options(tess2 PRIVATE
-          $<$<CXX_COMPILER_ID:GNU>: # supresses the following warnings for tess2
+          $<$<C_COMPILER_ID:GNU>: # suppresses the following warnings for tess2
             -Wno-clobbered>)
-
-target_compile_options(glfw PRIVATE
-          $<$<CXX_COMPILER_ID:GNU>: # supresses the following warnings for glfw
-            -Wno-unused-parameter -Wno-missing-field-initializers -Wno-sign-compare>)
 
 # googletest library
 if (${PROJECT_NAME}_BUILD_TESTING AND NOT TARGET gtest)

--- a/vendor/glad/CMakeLists.txt
+++ b/vendor/glad/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(GLAD)
+project(GLAD LANGUAGES C)
 
 include_directories(include)
 


### PR DESCRIPTION
# Description

# Changes

- Set MSVC runtime library
- Add default flags
- Changes MSVC warning level to /W4
- Remove intel flags.
- Minor changes to GitHub actions workflows.

# Test