### PR TITLE
Refactor functions for DRYer code

### DIFF
--- a/examples/awning.cpp
+++ b/examples/awning.cpp
@@ -31,8 +31,8 @@ int main() {
   std::shared_ptr<AwningLogger> logger = std::make_shared<AwningLogger>();
   Penumbra::Penumbra penumbra(512u, logger);
 
-  unsigned wall_id = penumbra.add_surface(wall);
-  unsigned window_id = penumbra.add_surface(window);
+  unsigned int wall_id = penumbra.add_surface(wall);
+  unsigned int window_id = penumbra.add_surface(window);
   [[maybe_unused]] auto awning_id = penumbra.add_surface(awning);
 
   penumbra.set_model();

--- a/include/penumbra/logging.h
+++ b/include/penumbra/logging.h
@@ -40,6 +40,17 @@ public:
   explicit PenumbraException(const std::string &message, Courierr::Courierr &logger)
       : CourierrException(message, logger) {}
 };
+
+class SurfaceException : public PenumbraException {
+public:
+  explicit SurfaceException(const unsigned int surface_index,
+                            const std::string_view &surface_context, Courierr::Courierr &logger)
+      : PenumbraException(fmt::format(error_message_format, surface_context, surface_index),
+                          logger) {}
+
+private:
+  static constexpr std::string_view error_message_format = "{} index, {}, does not exist.";
+};
 } // namespace Penumbra
 
 #endif // define PENUMBRA_LOGGING_H_

--- a/include/penumbra/penumbra.h
+++ b/include/penumbra/penumbra.h
@@ -32,7 +32,7 @@ public:
 
 public:
   static bool is_valid_context();
-  unsigned add_surface(const Surface &surface);
+  unsigned int add_surface(const Surface &surface);
   void set_model();
   void clear_model();
   void set_sun_position(float azimuth, // in radians, clockwise, north = 0
@@ -40,23 +40,23 @@ public:
   );
   float get_sun_azimuth();
   float get_sun_altitude();
-  void submit_pssa(unsigned surface_index);
-  void submit_pssa(const std::vector<unsigned> &surface_indices);
+  void submit_pssa(unsigned int surface_index);
+  void submit_pssa(const std::vector<unsigned int> &surface_indices);
   void submit_pssa();
-  unsigned get_number_of_surfaces();
-  float fetch_pssa(unsigned surface_index);
-  std::vector<float> fetch_pssa(const std::vector<unsigned> &surface_indices);
+  unsigned int get_number_of_surfaces();
+  float fetch_pssa(unsigned int surface_index);
+  std::vector<float> fetch_pssa(const std::vector<unsigned int> &surface_indices);
   std::vector<float> fetch_pssa();
-  float calculate_pssa(unsigned surface_index);
-  std::vector<float> calculate_pssa(const std::vector<unsigned> &surface_indices);
+  float calculate_pssa(unsigned int surface_index);
+  std::vector<float> calculate_pssa(const std::vector<unsigned int> &surface_indices);
   std::vector<float> calculate_pssa();
-  std::unordered_map<unsigned, float>
-  calculate_interior_pssas(const std::vector<unsigned> &transparent_surface_indices,
-                           const std::vector<unsigned> &interior_surface_indices);
-  void render_scene(unsigned surface_index); // Primarily for debug purposes
+  std::unordered_map<unsigned int, float>
+  calculate_interior_pssas(const std::vector<unsigned int> &transparent_surface_indices,
+                           const std::vector<unsigned int> &interior_surface_indices);
+  void render_scene(unsigned int surface_index); // Primarily for debug purposes
   void render_interior_scene(
-      std::vector<unsigned> transparent_surface_indices,
-      std::vector<unsigned> interior_surface_indices); // Primarily for debug purposes
+      const std::vector<unsigned int> &transparent_surface_indices,
+      const std::vector<unsigned int> &interior_surface_indices); // Primarily for debug purposes
   VendorType get_vendor_name();
   std::shared_ptr<Courierr::Courierr> get_logger();
 

--- a/include/penumbra/penumbra.h
+++ b/include/penumbra/penumbra.h
@@ -44,9 +44,9 @@ public:
   void submit_pssa(const std::vector<unsigned int> &surface_indices);
   void submit_pssa();
   unsigned int get_number_of_surfaces();
-  float fetch_pssa(unsigned int surface_index);
-  std::vector<float> fetch_pssa(const std::vector<unsigned int> &surface_indices);
-  std::vector<float> fetch_pssa();
+  float retrieve_pssa(unsigned int surface_index);
+  std::vector<float> retrieve_pssa(const std::vector<unsigned int> &surface_indices);
+  std::vector<float> retrieve_pssa();
   float calculate_pssa(unsigned int surface_index);
   std::vector<float> calculate_pssa(const std::vector<unsigned int> &surface_indices);
   std::vector<float> calculate_pssa();

--- a/src/gl/context.cpp
+++ b/src/gl/context.cpp
@@ -544,7 +544,7 @@ std::vector<float> Context::retrieve_pssas(const std::vector<unsigned int> &surf
   std::vector<float> pssas;
   pssas.reserve(surface_indices.size());
   for (const unsigned int surface_index : surface_indices) {
-    pssas.emplace_back(retrieve_pssa(surface_index));
+    pssas.push_back(retrieve_pssa(surface_index));
   }
   return pssas;
 }
@@ -553,7 +553,7 @@ std::vector<float> Context::retrieve_pssa() {
   std::vector<float> pssas;
   pssas.reserve(model.surface_buffers.size());
   for (auto const &surface_buffer : model.surface_buffers) {
-    pssas.emplace_back(retrieve_pssa(surface_buffer.index));
+    pssas.push_back(retrieve_pssa(surface_buffer.index));
   }
   return pssas;
 }

--- a/src/gl/context.cpp
+++ b/src/gl/context.cpp
@@ -455,7 +455,7 @@ void Context::draw_except(const std::vector<SurfaceBuffer> &hidden_surfaces) {
 #endif
 }
 
-void Context::show_rendering(const unsigned surface_index, mat4x4 sun_view) {
+void Context::show_rendering(const unsigned int surface_index, mat4x4 sun_view) {
   glfwSetWindowSize(window, size, size);
   glfwShowWindow(window);
 
@@ -479,7 +479,7 @@ void Context::show_rendering(const unsigned surface_index, mat4x4 sun_view) {
   initialize_off_screen_mode();
 }
 
-void Context::show_interior_rendering(const std::vector<unsigned> &hidden_surface_indices,
+void Context::show_interior_rendering(const std::vector<unsigned int> &hidden_surface_indices,
                                       const unsigned interior_surface_index, mat4x4 sun_view) {
   glfwSetWindowSize(window, size, size);
   glfwShowWindow(window);
@@ -519,11 +519,11 @@ void Context::submit_pssa(const SurfaceBuffer &surface_buffer, mat4x4 sun_view) 
   pixel_areas.at(surface_buffer.index) = pixel_area;
 }
 
-void Context::submit_pssa(const unsigned surface_index, mat4x4 sun_view) {
+void Context::submit_pssa(const unsigned int surface_index, mat4x4 sun_view) {
   submit_pssa(model.surface_buffers[surface_index], sun_view);
 }
 
-void Context::submit_pssa(const std::vector<unsigned> &surface_indices, mat4x4 sun_view) {
+void Context::submit_pssa(const std::vector<unsigned int> &surface_indices, mat4x4 sun_view) {
   for (auto const surface_index : surface_indices) {
     submit_pssa(surface_index, sun_view);
   }
@@ -535,13 +535,13 @@ void Context::submit_pssa(mat4x4 sun_view) {
   }
 }
 
-float Context::calculate_pssa(const unsigned surface_index) {
+float Context::calculate_pssa(const unsigned int surface_index) {
   // retrieve result
   glGetQueryObjectiv(queries[surface_index], GL_QUERY_RESULT, &(pixel_counts.at(surface_index)));
   return static_cast<float>(pixel_counts[surface_index]) * pixel_areas[surface_index];
 }
 
-std::vector<float> Context::calculate_pssa(const std::vector<unsigned> &surface_indices) {
+std::vector<float> Context::calculate_pssa(const std::vector<unsigned int> &surface_indices) {
 
   // retrieve result
   std::vector<float> results;

--- a/src/gl/context.h
+++ b/src/gl/context.h
@@ -73,12 +73,12 @@ private:
   double previous_x_position, previous_y_position;
   float camera_x_rotation_angle{0.f}, camera_y_rotation_angle{0.f};
   bool left_mouse_button_pressed{true};
-  bool is_render_mode{false};
   std::vector<GLuint> queries;
   std::vector<float> pixel_areas;
   std::vector<GLint> pixel_counts;
   Courierr::Courierr *logger;
 
+  void submit_pssa(const SurfaceBuffer &surface_buffer, mat4x4 sun_view);
   void draw_model();
   void draw_except(const std::vector<SurfaceBuffer> &hidden_surfaces);
   void set_mvp();

--- a/src/gl/context.h
+++ b/src/gl/context.h
@@ -32,21 +32,21 @@ class Context {
 public:
   Context(GLint size, Courierr::Courierr *logger);
   ~Context();
-  void show_rendering(unsigned surface_index, mat4x4 sun_view);
+  void show_rendering(unsigned int surface_index, mat4x4 sun_view);
   void set_model(const std::vector<float> &vertices,
                  const std::vector<SurfaceBuffer> &surface_buffers);
   float set_scene(mat4x4 sun_view, const SurfaceBuffer *surface_buffer = nullptr,
                   bool clip_far = true);
-  void submit_pssa(unsigned surface_index, mat4x4 sun_view);
-  void submit_pssa(const std::vector<unsigned> &surface_indices, mat4x4 sun_view);
+  void submit_pssa(unsigned int surface_index, mat4x4 sun_view);
+  void submit_pssa(const std::vector<unsigned int> &surface_indices, mat4x4 sun_view);
   void submit_pssa(mat4x4 sun_view);
-  float calculate_pssa(unsigned surface_index);
-  std::vector<float> calculate_pssa(const std::vector<unsigned> &surface_indices);
+  float calculate_pssa(unsigned int surface_index);
+  std::vector<float> calculate_pssa(const std::vector<unsigned int> &surface_indices);
   std::vector<float> calculate_pssa();
-  std::unordered_map<unsigned, float>
-  calculate_interior_pssas(const std::vector<unsigned> &hidden_surfaces,
-                           const std::vector<unsigned> &interior_surfaces, mat4x4 sun_view);
-  void show_interior_rendering(const std::vector<unsigned> &hidden_surface_indices,
+  std::unordered_map<unsigned int, float>
+  calculate_interior_pssas(const std::vector<unsigned int> &hidden_surfaces,
+                           const std::vector<unsigned int> &interior_surfaces, mat4x4 sun_view);
+  void show_interior_rendering(const std::vector<unsigned int> &hidden_surface_indices,
                                const unsigned int interior_surface_index, mat4x4 sun_view);
   void clear_model();
   static std::string get_vendor_name();

--- a/src/gl/context.h
+++ b/src/gl/context.h
@@ -38,21 +38,23 @@ public:
   float set_scene(mat4x4 sun_view, const SurfaceBuffer *surface_buffer = nullptr,
                   bool clip_far = true);
   void submit_pssa(unsigned int surface_index, mat4x4 sun_view);
-  void submit_pssa(const std::vector<unsigned int> &surface_indices, mat4x4 sun_view);
+  void submit_pssas(const std::vector<unsigned int> &surface_indices, mat4x4 sun_view);
   void submit_pssa(mat4x4 sun_view);
-  float calculate_pssa(unsigned int surface_index);
-  std::vector<float> calculate_pssa(const std::vector<unsigned int> &surface_indices);
-  std::vector<float> calculate_pssa();
+  float retrieve_pssa(unsigned int surface_index);
+  std::vector<float> retrieve_pssas(const std::vector<unsigned int> &surface_indices);
+  std::vector<float> retrieve_pssa();
+
   std::unordered_map<unsigned int, float>
-  calculate_interior_pssas(const std::vector<unsigned int> &hidden_surfaces,
-                           const std::vector<unsigned int> &interior_surfaces, mat4x4 sun_view);
+  calculate_interior_pssas(const std::vector<unsigned int> &hidden_surface_indices,
+                           const std::vector<unsigned int> &interior_surface_indices,
+                           mat4x4 sun_view);
   void show_interior_rendering(const std::vector<unsigned int> &hidden_surface_indices,
-                               const unsigned int interior_surface_index, mat4x4 sun_view);
+                               unsigned int interior_surface_index, mat4x4 sun_view);
   void clear_model();
   static std::string get_vendor_name();
 
 private:
-  GLFWwindow *window;
+  GLFWwindow *window{nullptr};
   GLuint framebuffer_object{}, renderbuffer_object{};
   static const char *render_vertex_shader_source;
   static const char *render_fragment_shader_source;

--- a/src/gl/context.h
+++ b/src/gl/context.h
@@ -16,12 +16,12 @@
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
 #include <courierr/courierr.h>
+#include <linmath.h> // Part of GLFW
 
 // Penumbra
-#include <sun.h>
-#include <gl/model.h>
-#include <gl/shader.h>
-#include <gl/program.h>
+#include "gl/model.h"
+#include "gl/shader.h"
+#include "gl/program.h"
 
 #define MAX_FLOAT std::numeric_limits<float>::max()
 

--- a/src/gl/model.cpp
+++ b/src/gl/model.cpp
@@ -5,7 +5,7 @@
 #include <algorithm>
 
 // Penumbra
-#include <gl/model.h>
+#include "model.h"
 
 #ifdef __APPLE__
 #define glGenVertexArraysX glGenVertexArraysAPPLE

--- a/src/gl/model.h
+++ b/src/gl/model.h
@@ -4,12 +4,12 @@
 #ifndef MODEL_H_
 #define MODEL_H_
 
+// Standard
+#include <vector>
+
 // Vendor
 #include <glad/glad.h>
 #include <GLFW/glfw3.h>
-
-// Standard
-#include <vector>
 
 namespace Penumbra {
 

--- a/src/gl/model.h
+++ b/src/gl/model.h
@@ -33,7 +33,7 @@ public:
   void clear_model();
   std::vector<float> vertex_array;
   std::vector<SurfaceBuffer> surface_buffers;
-  unsigned number_of_points{0};
+  unsigned int number_of_points{0u};
   static const int vertex_size{3}; // i.e., 3D
 private:
   GLuint vertex_buffer_object{}, vertex_array_object{};

--- a/src/gl/program.cpp
+++ b/src/gl/program.cpp
@@ -2,8 +2,8 @@
  * See the LICENSE file for additional terms and conditions. */
 
 // Penumbra
-#include <gl/program.h>
-#include <gl/shader.h>
+#include "program.h"
+#include "shader.h"
 
 namespace Penumbra {
 

--- a/src/penumbra-implementation.cpp
+++ b/src/penumbra-implementation.cpp
@@ -27,8 +27,11 @@ void PenumbraImplementation::add_surface(const Surface &surface) {
   surfaces.push_back(*surface.surface);
 }
 
-bool PenumbraImplementation::check_surface(const unsigned index) const {
-  return index < surfaces.size();
+void PenumbraImplementation::check_surface(const unsigned int surface_index,
+                                           const std::string_view &surface_context) const {
+  if (surface_index >= surfaces.size()) {
+    throw SurfaceException(surface_index, surface_context, *(logger));
+  }
 }
 
 } // namespace Penumbra

--- a/src/penumbra-implementation.h
+++ b/src/penumbra-implementation.h
@@ -32,7 +32,7 @@ public:
   std::vector<float> model;
   std::vector<SurfaceImplementation> surfaces;
   std::shared_ptr<Courierr::Courierr> logger;
-  [[nodiscard]] bool check_surface(unsigned index) const;
+  void check_surface(unsigned int index, const std::string_view &surface_context = "Surface") const;
 };
 
 } // namespace Penumbra

--- a/src/penumbra-implementation.h
+++ b/src/penumbra-implementation.h
@@ -13,8 +13,9 @@
 // Penumbra
 #include <penumbra/penumbra.h>
 #include <penumbra/surface.h>
-#include <surface-implementation.h>
-#include <gl/context.h>
+#include "surface-implementation.h"
+#include "sun.h"
+#include "gl/context.h"
 
 namespace Penumbra {
 

--- a/src/penumbra.cpp
+++ b/src/penumbra.cpp
@@ -74,12 +74,12 @@ VendorType Penumbra::get_vendor_name() {
   return vendor_type;
 }
 
-unsigned Penumbra::add_surface(const Surface &surface) {
+unsigned int Penumbra::add_surface(const Surface &surface) {
   penumbra->add_surface(surface);
   return static_cast<unsigned int>(penumbra->surfaces.size()) - 1u;
 }
 
-unsigned Penumbra::get_number_of_surfaces() {
+unsigned int Penumbra::get_number_of_surfaces() {
   return static_cast<unsigned int>(penumbra->surfaces.size());
 }
 
@@ -88,13 +88,13 @@ void Penumbra::set_model() {
 
     // Tessellate each surface into triangles
     std::vector<SurfaceBuffer> surface_buffers;
-    unsigned next_starting_index = 0;
-    unsigned surface_index = 0;
+    unsigned int next_starting_index{0u};
+    unsigned int surface_index{0u};
     for (auto &surface : penumbra->surfaces) {
       TessData tess = surface.tessellate();
       surface_buffers.emplace_back(next_starting_index / TessData::vertex_size,
                                    tess.number_of_vertices / TessData::vertex_size, surface_index);
-      for (unsigned i = 0; i < tess.number_of_vertices; ++i) {
+      for (unsigned int i = 0; i < tess.number_of_vertices; ++i) {
         penumbra->model.push_back(tess.vertices[i]);
       }
       next_starting_index += tess.number_of_vertices;
@@ -126,12 +126,12 @@ float Penumbra::get_sun_altitude() {
   return penumbra->sun.get_altitude();
 }
 
-void Penumbra::submit_pssa(unsigned surface_index) {
+void Penumbra::submit_pssa(unsigned int surface_index) {
   penumbra->check_surface(surface_index);
   penumbra->context.submit_pssa(surface_index, penumbra->sun.get_view());
 }
 
-void Penumbra::submit_pssa(const std::vector<unsigned> &surface_indices) {
+void Penumbra::submit_pssa(const std::vector<unsigned int> &surface_indices) {
   for (auto const surface_index : surface_indices) {
     penumbra->check_surface(surface_index);
   }
@@ -142,12 +142,12 @@ void Penumbra::submit_pssa() {
   penumbra->context.submit_pssa(penumbra->sun.get_view());
 }
 
-float Penumbra::fetch_pssa(unsigned surface_index) {
+float Penumbra::fetch_pssa(unsigned int surface_index) {
   penumbra->check_surface(surface_index);
   return penumbra->context.calculate_pssa(surface_index);
 }
 
-std::vector<float> Penumbra::fetch_pssa(const std::vector<unsigned> &surface_indices) {
+std::vector<float> Penumbra::fetch_pssa(const std::vector<unsigned int> &surface_indices) {
   for (auto const surface_index : surface_indices) {
     penumbra->check_surface(surface_index);
   }
@@ -158,12 +158,12 @@ std::vector<float> Penumbra::fetch_pssa() {
   return penumbra->context.calculate_pssa();
 }
 
-float Penumbra::calculate_pssa(unsigned surface_index) {
+float Penumbra::calculate_pssa(unsigned int surface_index) {
   submit_pssa(surface_index);
   return fetch_pssa(surface_index);
 }
 
-std::vector<float> Penumbra::calculate_pssa(const std::vector<unsigned> &surface_indices) {
+std::vector<float> Penumbra::calculate_pssa(const std::vector<unsigned int> &surface_indices) {
   submit_pssa(surface_indices);
   return fetch_pssa(surface_indices);
 }
@@ -173,10 +173,10 @@ std::vector<float> Penumbra::calculate_pssa() {
   return fetch_pssa();
 }
 
-std::unordered_map<unsigned, float>
-Penumbra::calculate_interior_pssas(const std::vector<unsigned> &transparent_surface_indices,
-                                   const std::vector<unsigned> &interior_surface_indices) {
-  std::unordered_map<unsigned, float> pssas;
+std::unordered_map<unsigned int, float>
+Penumbra::calculate_interior_pssas(const std::vector<unsigned int> &transparent_surface_indices,
+                                   const std::vector<unsigned int> &interior_surface_indices) {
+  std::unordered_map<unsigned int, float> pssas;
   if (!transparent_surface_indices.empty()) {
     for (auto const transparent_surface_index : transparent_surface_indices) {
       penumbra->check_surface(transparent_surface_index, "Transparent surface");
@@ -195,13 +195,13 @@ Penumbra::calculate_interior_pssas(const std::vector<unsigned> &transparent_surf
   return pssas;
 }
 
-void Penumbra::render_scene(unsigned surface_index) {
+void Penumbra::render_scene(unsigned int surface_index) {
   penumbra->check_surface(surface_index);
   penumbra->context.show_rendering(surface_index, penumbra->sun.get_view());
 }
 
-void Penumbra::render_interior_scene(std::vector<unsigned> transparent_surface_indices,
-                                     std::vector<unsigned> interior_surface_indices) {
+void Penumbra::render_interior_scene(const std::vector<unsigned int> &transparent_surface_indices,
+                                     const std::vector<unsigned int> &interior_surface_indices) {
   if (!transparent_surface_indices.empty()) {
     for (auto const transparent_surface_index : transparent_surface_indices) {
       penumbra->check_surface(transparent_surface_index, "Transparent surface");

--- a/src/penumbra.cpp
+++ b/src/penumbra.cpp
@@ -135,42 +135,42 @@ void Penumbra::submit_pssa(const std::vector<unsigned int> &surface_indices) {
   for (auto const surface_index : surface_indices) {
     penumbra->check_surface(surface_index);
   }
-  penumbra->context.submit_pssa(surface_indices, penumbra->sun.get_view());
+  penumbra->context.submit_pssas(surface_indices, penumbra->sun.get_view());
 }
 
 void Penumbra::submit_pssa() {
   penumbra->context.submit_pssa(penumbra->sun.get_view());
 }
 
-float Penumbra::fetch_pssa(unsigned int surface_index) {
+float Penumbra::retrieve_pssa(unsigned int surface_index) {
   penumbra->check_surface(surface_index);
-  return penumbra->context.calculate_pssa(surface_index);
+  return penumbra->context.retrieve_pssa(surface_index);
 }
 
-std::vector<float> Penumbra::fetch_pssa(const std::vector<unsigned int> &surface_indices) {
+std::vector<float> Penumbra::retrieve_pssa(const std::vector<unsigned int> &surface_indices) {
   for (auto const surface_index : surface_indices) {
     penumbra->check_surface(surface_index);
   }
-  return penumbra->context.calculate_pssa(surface_indices);
+  return penumbra->context.retrieve_pssas(surface_indices);
 }
 
-std::vector<float> Penumbra::fetch_pssa() {
-  return penumbra->context.calculate_pssa();
+std::vector<float> Penumbra::retrieve_pssa() {
+  return penumbra->context.retrieve_pssa();
 }
 
 float Penumbra::calculate_pssa(unsigned int surface_index) {
   submit_pssa(surface_index);
-  return fetch_pssa(surface_index);
+  return retrieve_pssa(surface_index);
 }
 
 std::vector<float> Penumbra::calculate_pssa(const std::vector<unsigned int> &surface_indices) {
   submit_pssa(surface_indices);
-  return fetch_pssa(surface_indices);
+  return retrieve_pssa(surface_indices);
 }
 
 std::vector<float> Penumbra::calculate_pssa() {
   submit_pssa();
-  return fetch_pssa();
+  return retrieve_pssa();
 }
 
 std::unordered_map<unsigned int, float>

--- a/src/penumbra.cpp
+++ b/src/penumbra.cpp
@@ -127,22 +127,13 @@ float Penumbra::get_sun_altitude() {
 }
 
 void Penumbra::submit_pssa(unsigned surface_index) {
-  if (penumbra->check_surface(surface_index)) {
-    penumbra->context.submit_pssa(surface_index, penumbra->sun.get_view());
-  } else {
-    throw PenumbraException(
-        fmt::format("Surface index, {}, does not exist. Cannot calculate PSSA.", surface_index),
-        *(penumbra->logger));
-  }
+  penumbra->check_surface(surface_index);
+  penumbra->context.submit_pssa(surface_index, penumbra->sun.get_view());
 }
 
 void Penumbra::submit_pssa(const std::vector<unsigned> &surface_indices) {
   for (auto const surface_index : surface_indices) {
-    if (!penumbra->check_surface(surface_index)) {
-      throw PenumbraException(
-          fmt::format("Surface index, {}, does not exist. Cannot calculate PSSA.", surface_index),
-          *(penumbra->logger));
-    }
+    penumbra->check_surface(surface_index);
   }
   penumbra->context.submit_pssa(surface_indices, penumbra->sun.get_view());
 }
@@ -152,22 +143,13 @@ void Penumbra::submit_pssa() {
 }
 
 float Penumbra::fetch_pssa(unsigned surface_index) {
-  if (penumbra->check_surface(surface_index)) {
-    return penumbra->context.calculate_pssa(surface_index);
-  } else {
-    throw PenumbraException(
-        fmt::format("Surface index, {}, does not exist. Cannot calculate PSSA.", surface_index),
-        *(penumbra->logger));
-  }
+  penumbra->check_surface(surface_index);
+  return penumbra->context.calculate_pssa(surface_index);
 }
 
 std::vector<float> Penumbra::fetch_pssa(const std::vector<unsigned> &surface_indices) {
   for (auto const surface_index : surface_indices) {
-    if (!penumbra->check_surface(surface_index)) {
-      throw PenumbraException(
-          fmt::format("Surface index, {}, does not exist. Cannot calculate PSSA.", surface_index),
-          *(penumbra->logger));
-    }
+    penumbra->check_surface(surface_index);
   }
   return penumbra->context.calculate_pssa(surface_indices);
 }
@@ -196,31 +178,15 @@ Penumbra::calculate_interior_pssas(const std::vector<unsigned> &transparent_surf
                                    const std::vector<unsigned> &interior_surface_indices) {
   std::unordered_map<unsigned, float> pssas;
   if (!transparent_surface_indices.empty()) {
-    if (penumbra->check_surface(transparent_surface_indices[0])) {
-      for (auto const transparent_surface_index : transparent_surface_indices) {
-        if (!penumbra->check_surface(transparent_surface_index)) {
-          throw PenumbraException(
-              fmt::format("Transparent surface index, {}, does not exist. Cannot calculate PSSA.",
-                          transparent_surface_index),
-              *(penumbra->logger));
-        }
-      }
-      for (auto const interior_surface_index : interior_surface_indices) {
-        if (!penumbra->check_surface(interior_surface_index)) {
-          throw PenumbraException(
-              fmt::format("Interior surface index, {}, does not exist. Cannot calculate PSSA.",
-                          interior_surface_index),
-              *(penumbra->logger));
-        }
-      }
-      pssas = penumbra->context.calculate_interior_pssas(
-          transparent_surface_indices, interior_surface_indices, penumbra->sun.get_view());
-    } else {
-      throw PenumbraException(
-          fmt::format("Transparent surface index, {}, does not exist. Cannot calculate PSSA.",
-                      transparent_surface_indices[0]),
-          *(penumbra->logger));
+    for (auto const transparent_surface_index : transparent_surface_indices) {
+      penumbra->check_surface(transparent_surface_index, "Transparent surface");
     }
+    for (auto const interior_surface_index : interior_surface_indices) {
+      penumbra->check_surface(interior_surface_index, "Interior surface");
+    }
+    pssas = penumbra->context.calculate_interior_pssas(
+        transparent_surface_indices, interior_surface_indices, penumbra->sun.get_view());
+
   } else {
     throw PenumbraException(
         "Cannot calculate interior PSSAs without defining at least one transparent surface index.",
@@ -230,43 +196,20 @@ Penumbra::calculate_interior_pssas(const std::vector<unsigned> &transparent_surf
 }
 
 void Penumbra::render_scene(unsigned surface_index) {
-  if (penumbra->check_surface(surface_index)) {
-    penumbra->context.show_rendering(surface_index, penumbra->sun.get_view());
-  } else {
-    throw PenumbraException(
-        fmt::format("Surface index, {}, does not exist. Cannot render scene.", surface_index),
-        *(penumbra->logger));
-  }
+  penumbra->check_surface(surface_index);
+  penumbra->context.show_rendering(surface_index, penumbra->sun.get_view());
 }
 
 void Penumbra::render_interior_scene(std::vector<unsigned> transparent_surface_indices,
                                      std::vector<unsigned> interior_surface_indices) {
   if (!transparent_surface_indices.empty()) {
-    if (penumbra->check_surface(transparent_surface_indices[0])) {
-      for (auto &transparent_surface_index : transparent_surface_indices) {
-        if (!penumbra->check_surface(transparent_surface_index)) {
-          throw PenumbraException(
-              fmt::format("Transparent surface index, {}, does not exist. Cannot render scene.",
-                          transparent_surface_index),
-              *(penumbra->logger));
-        }
-      }
-      for (auto &interior_surface_index : interior_surface_indices) {
-        if (penumbra->check_surface(interior_surface_index)) {
-          penumbra->context.showInteriorRendering(transparent_surface_indices,
-                                                  interior_surface_index, penumbra->sun.get_view());
-        } else {
-          throw PenumbraException(
-              fmt::format("Interior surface index, {}, does not exist. Cannot render scene.",
-                          interior_surface_index),
-              *(penumbra->logger));
-        }
-      }
-    } else {
-      throw PenumbraException(
-          fmt::format("Transparent surface index, {}, does not exist. Cannot render scene.",
-                      transparent_surface_indices[0]),
-          *(penumbra->logger));
+    for (auto const transparent_surface_index : transparent_surface_indices) {
+      penumbra->check_surface(transparent_surface_index, "Transparent surface");
+    }
+    for (auto const interior_surface_index : interior_surface_indices) {
+      penumbra->check_surface(interior_surface_index, "Interior surface");
+      penumbra->context.showInteriorRendering(transparent_surface_indices, interior_surface_index,
+                                              penumbra->sun.get_view());
     }
   } else {
     throw PenumbraException("Cannot render interior scene without defining at least one "

--- a/src/penumbra.cpp
+++ b/src/penumbra.cpp
@@ -13,7 +13,7 @@
 
 // Penumbra
 #include <penumbra/penumbra.h>
-#include <penumbra-implementation.h>
+#include "penumbra-implementation.h"
 
 namespace Penumbra {
 

--- a/src/sun.cpp
+++ b/src/sun.cpp
@@ -2,7 +2,7 @@
  * See the LICENSE file for additional terms and conditions. */
 
 // Penumbra
-#include <sun.h>
+#include "sun.h"
 
 namespace Penumbra {
 

--- a/src/sun.h
+++ b/src/sun.h
@@ -6,9 +6,9 @@
 
 // Standard
 #include <cmath>
-#include <linmath.h>
 
 // Vendor
+#include <linmath.h> // Part of GLFW
 #include <courierr/courierr.h>
 
 namespace Penumbra {
@@ -23,7 +23,6 @@ public:
 public:
   mat4x4_ptr get_view();
   void set_view(float azimuth, float altitude);
-  // void set_view(mat4x4 view);
   [[nodiscard]] float get_azimuth() const;
   [[nodiscard]] float get_altitude() const;
 

--- a/src/surface-implementation.cpp
+++ b/src/surface-implementation.cpp
@@ -7,8 +7,8 @@
 
 // Penumbra
 #include <penumbra/surface.h>
-#include "surface-implementation.h"
 #include <penumbra/logging.h>
+#include "surface-implementation.h"
 
 namespace Penumbra {
 

--- a/src/surface-implementation.h
+++ b/src/surface-implementation.h
@@ -4,13 +4,13 @@
 #ifndef SURFACE_IMPLEMENTATION_H_
 #define SURFACE_IMPLEMENTATION_H_
 
-// Vendor
-#include <tesselator.h>
-#include <courierr/courierr.h>
-
 // Standard
 #include <vector>
 #include <array>
+
+// Vendor
+#include <tesselator.h>
+#include <courierr/courierr.h>
 
 namespace Penumbra {
 

--- a/src/surface-implementation.h
+++ b/src/surface-implementation.h
@@ -15,9 +15,9 @@
 namespace Penumbra {
 
 struct TessData {
-  TessData(const float *array, unsigned number_of_vertices);
+  TessData(const float *array, unsigned int number_of_vertices);
   std::vector<float> vertices;
-  unsigned number_of_vertices;
+  unsigned int number_of_vertices;
   static const int polygon_size{3}; // making triangles
   static const int vertex_size{3};  // i.e., 3D
 };

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -7,7 +7,7 @@
 
 // Penumbra
 #include <penumbra/surface.h>
-#include <surface-implementation.h>
+#include "surface-implementation.h"
 
 namespace Penumbra {
 

--- a/test/penumbra_test.cpp
+++ b/test/penumbra_test.cpp
@@ -67,7 +67,7 @@ TEST(PenumbraTest, azimuth) {
   }
   Penumbra::Surface wall({0.f, 0.f, 0.f, 1.f, 0.f, 0.f, 1.f, 0.f, 1.f, 0.f, 0.f, 1.f}, "Wall");
   Penumbra::Penumbra penumbra;
-  unsigned wall_id = penumbra.add_surface(wall);
+  unsigned int wall_id = penumbra.add_surface(wall);
   penumbra.set_model();
   // Loop azimuth around the surface (with zero altitude).
   for (float azimuth = 0.0f; azimuth <= 2 * m_pi_f; azimuth += m_pi_4_f) {
@@ -180,13 +180,13 @@ TEST(PenumbraTest, interior) {
 
   Penumbra::Penumbra penumbra;
 
-  unsigned front_wall_id = penumbra.add_surface(front_wall);
-  unsigned window_id = penumbra.add_surface(window);
-  unsigned back_wall_id = penumbra.add_surface(back_wall);
-  [[maybe_unused]] unsigned roof_id = penumbra.add_surface(roof);
-  unsigned floor_id = penumbra.add_surface(floor);
-  unsigned left_wall_id = penumbra.add_surface(left_wall);
-  unsigned right_wall_id = penumbra.add_surface(right_wall);
+  unsigned int front_wall_id = penumbra.add_surface(front_wall);
+  unsigned int window_id = penumbra.add_surface(window);
+  unsigned int back_wall_id = penumbra.add_surface(back_wall);
+  [[maybe_unused]] unsigned int roof_id = penumbra.add_surface(roof);
+  unsigned int floor_id = penumbra.add_surface(floor);
+  unsigned int left_wall_id = penumbra.add_surface(left_wall);
+  unsigned int right_wall_id = penumbra.add_surface(right_wall);
 
   penumbra.set_model();
   penumbra.set_sun_position(0.0f, 0.f);
@@ -203,7 +203,7 @@ TEST(PenumbraTest, interior) {
   // penumbra.render_scene(front_wall_id);
 
   penumbra.set_sun_position(0.5f, 0.5f);
-  std::unordered_map<unsigned, float> interior_pssas = penumbra.calculate_interior_pssas(
+  std::unordered_map<unsigned int, float> interior_pssas = penumbra.calculate_interior_pssas(
       {window_id}, {back_wall_id, floor_id, left_wall_id, right_wall_id});
   EXPECT_GT(interior_pssas[back_wall_id], 0.f);
   EXPECT_GT(interior_pssas[floor_id], 0.f);
@@ -314,8 +314,8 @@ TEST(PenumbraTest, calculate_pssa_multiple_surfaces) {
   const unsigned int left_wall_id = penumbra.add_surface(left_wall);
   const unsigned int right_wall_id = penumbra.add_surface(right_wall);
 
-  const std::vector<unsigned> test_cube{front_wall_id, back_wall_id, roof_id,
-                                        floor_id,      left_wall_id, right_wall_id};
+  const std::vector<unsigned int> test_cube{front_wall_id, back_wall_id, roof_id,
+                                            floor_id,      left_wall_id, right_wall_id};
 
   penumbra.set_model();
 
@@ -443,7 +443,7 @@ TEST(PenumbraTest, bad_surface_input_errors) {
     GTEST_SKIP() << invalid_context_string << std::endl;
   }
 
-  const std::vector<unsigned> bad_test_cube{5, 6, 7, 8, 9, 10};
+  const std::vector<unsigned int> bad_test_cube{5, 6, 7, 8, 9, 10};
   Penumbra::Surface front_wall({-.5f, .5f, -.5f, .5f, .5f, -.5f, .5f, .5f, .5f, -.5f, .5f, .5f});
   Penumbra::Surface back_wall({.5f, -.5f, -.5f, -.5f, -.5f, -.5f, -.5f, -.5f, .5f, .5f, -.5f, .5f});
   Penumbra::Surface roof({-.5f, .5f, .5f, .5f, .5f, .5f, .5f, -.5f, .5f, -.5f, -.5f, .5f});

--- a/test/penumbra_test.cpp
+++ b/test/penumbra_test.cpp
@@ -460,7 +460,7 @@ TEST(PenumbraTest, bad_surface_input_errors) {
 
   EXPECT_THROW(penumbra.render_scene(11), Penumbra::PenumbraException);
 
-  EXPECT_THROW(penumbra.fetch_pssa(bad_test_cube), Penumbra::PenumbraException);
+  EXPECT_THROW(penumbra.retrieve_pssa(bad_test_cube), Penumbra::PenumbraException);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Also:

- Use consistent convention for `unsigned int`
- Clean up include statements